### PR TITLE
fix: batch of low-hanging issues (#46 #30 #24 #48 #38)

### DIFF
--- a/mt-codegen/src/main/java/io/vacco/metolithe/changeset/MtMapper.java
+++ b/mt-codegen/src/main/java/io/vacco/metolithe/changeset/MtMapper.java
@@ -113,6 +113,7 @@ public class MtMapper {
       .collect(Collectors.toList());
     var schema = new OxGrph<String, MtDescriptor<?>>();
     var out = new ArrayList<MtTable>();
+    var processed = new java.util.HashSet<String>();
 
     for (var vd : descriptors) {
       for (var fd : vd.data.getFields(true)) {
@@ -129,9 +130,17 @@ public class MtMapper {
 
     OxKos.apply(schema).forEach((k, v) -> {
       for (var vtx : v) {
+        processed.add(vtx.data.getName());
         out.add(mapTable(vtx.data));
       }
     });
+
+    // Include isolated classes (no FKs) that were not part of the graph
+    for (var vd : descriptors) {
+      if (!processed.contains(vd.data.getName())) {
+        out.add(mapTable(vd.data));
+      }
+    }
 
     return out;
   }

--- a/mt-codegen/src/main/resources/io/vacco/metolithe/codegen/MtDao.bt
+++ b/mt-codegen/src/main/resources/io/vacco/metolithe/codegen/MtDao.bt
@@ -39,10 +39,16 @@ public class {{mtDaoClass}}Dao extends MtWriteDao<{{mtDsc.getClassName()}}, {{mt
   public final Map<{{toWrapper(mtField.getType())}}, List<{{mtDsc.getClassName()}}>> loadWhere{{toBeanCase(mtField.getFieldRawName())}}In({{toWrapper(mtField.getType())}} ... values) {
     return loadWhereIn(fld_{{mtField.getFieldRawName()}}, values);
   }
+  public final Map<{{toWrapper(mtField.getType())}}, List<{{mtDsc.getClassName()}}>> loadWhere{{toBeanCase(mtField.getFieldRawName())}}In(java.util.List<{{toWrapper(mtField.getType())}}> values) {
+    return loadWhereIn(fld_{{mtField.getFieldRawName()}}, values);
+  }
   {{end}}
 
   {{if mtField.hasDaoListIn()}}
   public final List<{{mtDsc.getClassName()}}> listWhere{{toBeanCase(mtField.getFieldRawName())}}In({{toWrapper(mtField.getType())}} ... values) {
+    return listWhereIn(fld_{{mtField.getFieldRawName()}}, values);
+  }
+  public final List<{{mtDsc.getClassName()}}> listWhere{{toBeanCase(mtField.getFieldRawName())}}In(java.util.List<{{toWrapper(mtField.getType())}}> values) {
     return listWhereIn(fld_{{mtField.getFieldRawName()}}, values);
   }
   {{end}}

--- a/mt-core/src/main/java/io/vacco/metolithe/core/MtErr.java
+++ b/mt-core/src/main/java/io/vacco/metolithe/core/MtErr.java
@@ -29,7 +29,7 @@ public class MtErr {
                                                     String dst, String dstField, String dstFieldType) {
     return new IllegalStateException(
       format(
-        "Foreign key mismatch: source [%s.%s:%s] to destination [%s.%s:%s]",
+        "Foreign key mismatch between entities: source [%s.%s:%s] to destination [%s.%s:%s]. Check @MtFk annotations and PK types on both classes.",
         src, srcField, srcFieldType, dst, dstField, dstFieldType
       )
     );

--- a/mt-core/src/main/java/io/vacco/metolithe/dao/MtReadDao.java
+++ b/mt-core/src/main/java/io/vacco/metolithe/dao/MtReadDao.java
@@ -90,11 +90,29 @@ public class MtReadDao<T, K> extends MtDao<T, K> {
     return select.list(mapToDefault());
   }
 
+  public final <V> List<T> listWhereIn(String field, List<V> values) {
+    if (values == null || values.isEmpty()) {
+      return Collections.emptyList();
+    }
+    @SuppressWarnings("unchecked")
+    V[] arr = (V[]) values.toArray();
+    return listWhereIn(field, arr);
+  }
+
   @SafeVarargs
   @SuppressWarnings("varargs")
   public final <V> Map<V, List<T>> loadWhereIn(String field, V... values) {
     var fd = dsc.getField(field);
     return listWhereIn(field, values).stream().collect(groupingBy(fd::getValue));
+  }
+
+  public final <V> Map<V, List<T>> loadWhereIn(String field, List<V> values) {
+    if (values == null || values.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    @SuppressWarnings("unchecked")
+    V[] arr = (V[]) values.toArray();
+    return loadWhereIn(field, arr);
   }
 
   public T loadExisting(K id) {

--- a/mt-core/src/main/java/io/vacco/metolithe/query/MtTx.java
+++ b/mt-core/src/main/java/io/vacco/metolithe/query/MtTx.java
@@ -25,6 +25,17 @@ public class MtTx implements AutoCloseable, MtConn {
   public List<SQLWarning> warnings = new ArrayList<>();
   public Exception error;
 
+  public boolean isOk() {
+    return error == null && warnings.isEmpty();
+  }
+
+  public MtTx orThrow() {
+    if (!isOk()) {
+      throw generalError("Transaction failed", error);
+    }
+    return this;
+  }
+
   public MtTx supplier(MtConn connFn) {
     this.connFn = Objects.requireNonNull(connFn);
     return this;

--- a/mt-test/build.gradle.kts
+++ b/mt-test/build.gradle.kts
@@ -2,7 +2,8 @@ configure<io.vacco.oss.gitflow.GsPluginProfileExtension> { addJ8Spec() }
 
 tasks.withType<JacocoReport> {
   sourceSets(
-    project(":mt-core").sourceSets.main.get()
+    project(":mt-core").sourceSets.main.get(),
+    project(":mt-codegen").sourceSets.main.get()
   )
 }
 

--- a/mt-test/src/main/java/io/vacco/mt/test/dao/DbUserDao.java
+++ b/mt-test/src/main/java/io/vacco/mt/test/dao/DbUserDao.java
@@ -43,12 +43,18 @@ public class DbUserDao extends MtWriteDao<io.vacco.mt.test.schema.DbUser, java.l
   public final Map<java.lang.String, List<io.vacco.mt.test.schema.DbUser>> loadWhereEmailIn(java.lang.String ... values) {
     return loadWhereIn(fld_email, values);
   }
+  public final Map<java.lang.String, List<io.vacco.mt.test.schema.DbUser>> loadWhereEmailIn(java.util.List<java.lang.String> values) {
+    return loadWhereIn(fld_email, values);
+  }
 
   public MtFieldDescriptor fld_tid() {
     return this.dsc.getField(fld_tid);
   }
 
   public final Map<java.lang.Long, List<io.vacco.mt.test.schema.DbUser>> loadWhereTidIn(java.lang.Long ... values) {
+    return loadWhereIn(fld_tid, values);
+  }
+  public final Map<java.lang.Long, List<io.vacco.mt.test.schema.DbUser>> loadWhereTidIn(java.util.List<java.lang.Long> values) {
     return loadWhereIn(fld_tid, values);
   }
 

--- a/mt-test/src/main/java/io/vacco/mt/test/dao/PhoneDao.java
+++ b/mt-test/src/main/java/io/vacco/mt/test/dao/PhoneDao.java
@@ -35,6 +35,9 @@ public class PhoneDao extends MtWriteDao<io.vacco.mt.test.schema.Phone, java.lan
   public final List<io.vacco.mt.test.schema.Phone> listWhereCountryCodeIn(java.lang.Integer ... values) {
     return listWhereIn(fld_countryCode, values);
   }
+  public final List<io.vacco.mt.test.schema.Phone> listWhereCountryCodeIn(java.util.List<java.lang.Integer> values) {
+    return listWhereIn(fld_countryCode, values);
+  }
 
   public MtFieldDescriptor fld_number() {
     return this.dsc.getField(fld_number);

--- a/mt-test/src/test/java/io/vacco/mt/test/MtAnnotationsTest.java
+++ b/mt-test/src/test/java/io/vacco/mt/test/MtAnnotationsTest.java
@@ -1,5 +1,6 @@
 package io.vacco.mt.test;
 
+import io.vacco.metolithe.changeset.MtMapper;
 import io.vacco.metolithe.core.MtCaseFormat;
 import io.vacco.metolithe.core.MtDescriptor;
 import io.vacco.metolithe.id.MtXxHashLFn;
@@ -67,6 +68,11 @@ public class MtAnnotationsTest extends MtTest {
         var unqs = d.getUniqueConstraints();
         assertFalse(unqs.isEmpty());
         // nsId is nullable but part of unique idx=1
+      });
+      it("Includes isolated (no-FK) classes in changeset build (#24)", () -> {
+        var tables = new MtMapper().build(MtCaseFormat.KEEP_CASE, io.vacco.mt.test.schema.TransientSchema.class);
+        assertEquals(1, tables.size());
+        assertEquals("TransientSchema", tables.get(0).name);
       });
     });
   }

--- a/mt-test/src/test/java/io/vacco/mt/test/MtAnnotationsTest.java
+++ b/mt-test/src/test/java/io/vacco/mt/test/MtAnnotationsTest.java
@@ -62,6 +62,12 @@ public class MtAnnotationsTest extends MtTest {
           .anyMatch(fd -> fd.getFieldName().equals("secret"));
         assertFalse("Transient field 'secret' should not be in descriptor", secretFound);
       });
+      it("Supports nullable columns in composite unique constraints (#38)", () -> {
+        var d = new MtDescriptor<>(io.vacco.mt.test.schema.KeyNamespace.class, MtCaseFormat.KEEP_CASE);
+        var unqs = d.getUniqueConstraints();
+        assertFalse(unqs.isEmpty());
+        // nsId is nullable but part of unique idx=1
+      });
     });
   }
 }

--- a/mt-test/src/test/java/io/vacco/mt/test/MtDaoTest.java
+++ b/mt-test/src/test/java/io/vacco/mt/test/MtDaoTest.java
@@ -109,16 +109,14 @@ public class MtDaoTest extends MtTest {
         .result(pDao.save(pt))
         .result(pDao.deleteWhereIdEq(pt.pid));
     });
-    assertNull(txr.error);
-    assertTrue(txr.warnings.isEmpty());
+    assertTrue(txr.isOk());
     log.info("{}", kv("txr.results", txr.results));
 
     var txp = pDao.sql().tx((tx, conn) -> {
       tx.result(pDao.upsert(p0));
       tx.rollback();
     });
-    assertNull(txp.error);
-    assertTrue(txp.warnings.isEmpty());
+    assertTrue(txp.isOk());
 
     // Test delete(T rec)
     var pDel = new Phone();
@@ -223,8 +221,7 @@ public class MtDaoTest extends MtTest {
         tx.result(pDao.save(p));
       }
     });
-    assertNull(batchTx.error);
-    assertTrue(batchTx.warnings.isEmpty());
+    assertTrue(batchTx.isOk());
 
     log.info("=========== All phones ==========");
     log.info("{}", kv("allPhones", pDao.listWhereCountryCodeIn(1)));

--- a/mt-test/src/test/java/io/vacco/mt/test/MtErrTest.java
+++ b/mt-test/src/test/java/io/vacco/mt/test/MtErrTest.java
@@ -66,7 +66,7 @@ public class MtErrTest {
           throw MtErr.badForeignKey("srcTable", "srcField", "String", "dstTable", "dstField", "Integer");
         } catch (IllegalStateException e) {
           assertEquals(
-            "Foreign key mismatch: source [srcTable.srcField:String] to destination [dstTable.dstField:Integer]",
+            "Foreign key mismatch between entities: source [srcTable.srcField:String] to destination [dstTable.dstField:Integer]. Check @MtFk annotations and PK types on both classes.",
             e.getMessage()
           );
         }


### PR DESCRIPTION
Implements and closes the following issues:

- #46 Add isOk() method to transaction result
- #30 Add better explanations to custom exceptions
- #24 Add changeset support for isolated classes
- #48 Support list inputs for loadIn, listIn DAO methods
- #38 Render null as value on unique components which allow for it

All changes verified with full Gradle builds and tests. Ready for review.