### PR TITLE
fix: clear conn ref after tx (#47) + add BigDecimal/decimal support (#23)

### DIFF
--- a/mt-core/src/main/java/io/vacco/metolithe/core/MtUtil.java
+++ b/mt-core/src/main/java/io/vacco/metolithe/core/MtUtil.java
@@ -58,6 +58,9 @@ public class MtUtil {
     if (wt0 == Float.class) {
       return "float";
     }
+    if (wt0 == java.math.BigDecimal.class) {
+      return "decimal";
+    }
     if (Enum.class.isAssignableFrom(fd.getType())) {
       return format("varchar(%s)", ENUM_VARCHAR_LENGTH);
     }

--- a/mt-core/src/main/java/io/vacco/metolithe/query/MtCmd.java
+++ b/mt-core/src/main/java/io/vacco/metolithe/query/MtCmd.java
@@ -13,7 +13,7 @@ public class MtCmd {
 
   private final Map<String, Object> params = new LinkedHashMap<>();
   private final List<Object> values = new ArrayList<>();
-  private final MtConn connFn;
+  private MtConn connFn;
 
   public String sqlP;
   private final String sql;
@@ -92,6 +92,10 @@ public class MtCmd {
 
   public <T> Optional<T> one(MtMapper<T> mapper) {
     return list(mapper).stream().findFirst();
+  }
+
+  void clearConnection() {
+    this.connFn = null;
   }
 
 }

--- a/mt-core/src/main/java/io/vacco/metolithe/query/MtTx.java
+++ b/mt-core/src/main/java/io/vacco/metolithe/query/MtTx.java
@@ -131,6 +131,11 @@ public class MtTx implements AutoCloseable, MtConn {
         MtLog.warn("Failed to close connection", e);
       }
     }
+    for (var res : results) {
+      if (res != null && res.cmd != null) {
+        res.cmd.clearConnection();
+      }
+    }
   }
 
   @Override

--- a/mt-test/src/main/java/io/vacco/mt/test/schema/TransientSchema.java
+++ b/mt-test/src/main/java/io/vacco/mt/test/schema/TransientSchema.java
@@ -11,5 +11,7 @@ public class TransientSchema {
   @MtVarchar(255)
   public String name;
 
+  public java.math.BigDecimal amount;
+
   public transient String secret;
 }

--- a/mt-test/src/test/java/io/vacco/mt/test/MtAnnotationsTest.java
+++ b/mt-test/src/test/java/io/vacco/mt/test/MtAnnotationsTest.java
@@ -3,6 +3,7 @@ package io.vacco.mt.test;
 import io.vacco.metolithe.changeset.MtMapper;
 import io.vacco.metolithe.core.MtCaseFormat;
 import io.vacco.metolithe.core.MtDescriptor;
+import io.vacco.metolithe.core.MtUtil;
 import io.vacco.metolithe.id.MtXxHashLFn;
 import io.vacco.mt.test.schema.DbUser;
 import io.vacco.mt.test.schema.Device;
@@ -56,12 +57,16 @@ public class MtAnnotationsTest extends MtTest {
       });
       it("Filters transient fields", () -> {
         var descriptor = new MtDescriptor<>(TransientSchema.class, MtCaseFormat.KEEP_CASE);
-        // Should only have 2 fields: id and name. 'secret' should be ignored.
-        assertEquals(2, descriptor.getFields(true).size());
+        // Should only have 3 fields: id, name, amount. 'secret' should be ignored.
+        assertEquals(3, descriptor.getFields(true).size());
         boolean secretFound = descriptor.getFields(true)
           .stream()
           .anyMatch(fd -> fd.getFieldName().equals("secret"));
         assertFalse("Transient field 'secret' should not be in descriptor", secretFound);
+        var amountField = descriptor.getFields(true).stream()
+          .filter(fd -> fd.getFieldName().equals("amount"))
+          .findFirst().orElseThrow();
+        assertEquals("decimal", MtUtil.sqlTypeOf(amountField));
       });
       it("Supports nullable columns in composite unique constraints (#38)", () -> {
         var d = new MtDescriptor<>(io.vacco.mt.test.schema.KeyNamespace.class, MtCaseFormat.KEEP_CASE);


### PR DESCRIPTION
Implements and closes:

- #47 Clear connection reference in MtCmd once transaction has ended
- #23 Add SQL Decimal support

Includes test coverage for the decimal type mapping.

Ready for review.